### PR TITLE
Add -nostdlib when compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ target_include_directories(${PROJECT_NAME}
         src
 )
 
+target_compile_options(${PROJECT_NAME}
+    PUBLIC
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
+            -nostdlib
+        >
+)
+
 target_link_options(${PROJECT_NAME}
     PUBLIC
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:


### PR DESCRIPTION
Solves #13.
Can also only add -fno-stack-protector instead. What do you think is better? -nostdlib is perhaps a linker flag only? But it affects the compilation so not sure...