### PR TITLE
Add travis with jobs for gcc and clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,82 @@
+language: cpp
+dist: bionic
+
+addons:
+  apt:
+    packages: &common-apt-packages
+      - python3-pip
+
+matrix:
+  include:
+    - name: "gcc 7"
+      addons: &gcc7
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *common-apt-packages
+            - g++-7
+      env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 BUILD_TYPE=Debug"
+
+    - name: "gcc 8"
+      addons: &gcc8
+        apt:
+          packages:
+            - *common-apt-packages
+            - g++-8
+      env: MATRIX_EVAL="CC=gcc-8 CXX=g++-8 BUILD_TYPE=Debug"
+
+    - name: "gcc 9"
+      addons: &gcc9
+        apt:
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+          packages:
+            - *common-apt-packages
+            - g++-9
+      env: MATRIX_EVAL="CC=gcc-9 CXX=g++-9 BUILD_TYPE=Debug"
+
+    - name: "clang 7"
+      addons: &clang7
+        apt:
+          packages:
+            - *common-apt-packages
+            - clang-7
+            - libstdc++-7-dev
+      env: MATRIX_EVAL="CC=clang-7 CXX=clang++-7 BUILD_TYPE=Debug"
+
+    - name: "clang 8"
+      addons: &clang8
+        apt:
+          packages:
+            - *common-apt-packages
+            - clang-8
+            - libstdc++-8-dev
+      env: MATRIX_EVAL="CC=clang-8 CXX=clang++-8 BUILD_TYPE=Debug"
+
+    - name: "clang 9"
+      addons: &clang9
+        apt:
+          sources:
+            - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - *common-apt-packages
+            - clang-9
+            - libstdc++-8-dev
+      env: MATRIX_EVAL="CC=clang-9 CXX=clang++-9 BUILD_TYPE=Debug"
+
+install:
+  - python3 -m pip install pip==19.3.1 --upgrade
+  - python3 -m pip install cmake==3.16.3 ninja==1.9.0.post1 --upgrade --user
+
+before_script:
+  - cmake --version
+  - ninja --version
+  - mkdir _build && cd _build
+  - eval "${MATRIX_EVAL}"
+
+script:
+  - cmake -DCMAKE_BUILD_TYPE="$BUILD_TYPE" $CMAKE_EXTRA_OPTIONS ..
+  - cmake --build . --parallel 2
+  - ctest --output-on-failure


### PR DESCRIPTION
Gcc build will fail due to #13, fixed by #15.

Next step is to add jobs for x86.

Resolves #6 
Resolves #7 