### PR TITLE
Pass command line arguments to main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,16 +14,19 @@ STRING(REGEX REPLACE "[/|-]RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAG
 
 add_library(${PROJECT_NAME}
     src/exit.c
-    src/start.c
+    src/stdlib2_start.c
     src/string.c
     $<$<PLATFORM_ID:Windows>:
         src/platform/win_x86_64/_exit.c
+        src/start.c
     >
     $<$<AND:$<BOOL:${x86}>,$<PLATFORM_ID:Linux>>:
         src/platform/linux_x86/_exit.s
+        src/start.c
     >
     $<$<AND:$<NOT:${x86}>,$<PLATFORM_ID:Linux>>:
         src/platform/linux_x86_64/_exit.s
+        src/platform/linux_x86_64/_start.s
     >
 )
 

--- a/src/platform/linux_x86_64/_start.s
+++ b/src/platform/linux_x86_64/_start.s
@@ -1,0 +1,23 @@
+.global _start
+
+.text
+_start:
+   # From the 'System V Application Binary Interface'
+
+   # From Figure 3.9: Initial Process Stack
+   # %rbp: Unspecified at process initialization time,
+   #       but should be set to zero to mark the depest stack frame
+   # %rsp: Holds the address of the byte with lowest address which
+   #       is part of the stack. Guaranteed to be 16-byte aligned at process entry.
+
+   # From Figure 3.4: Register Usage
+   # %rdi used to pass 1st argument to functions
+   # %rsi used to pass 2nd argument to functions
+
+   xor %rbp, %rbp
+   movq (%rsp), %rdi # load argc
+   lea 8(%rsp), %rsi # calc argv (pointer to the array on the stack)
+
+   call _stdlib2_start
+
+   hlt # should never get here

--- a/src/start.c
+++ b/src/start.c
@@ -1,7 +1,8 @@
 #include "stdlib.h"
+#include "stddef.h"
 
-int main2();
+int _stdlib2_start();
 
 void _start() {
-    exit(main2());
+    exit(_stdlib2_start(0, NULL));
 }

--- a/src/stdlib2_start.c
+++ b/src/stdlib2_start.c
@@ -1,0 +1,7 @@
+#include "stdlib.h"
+
+int main2(int argc, char *argv[]);
+
+void _stdlib2_start(int argc, char *argv[]) {
+    exit(main2(argc, argv));
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,10 +8,13 @@ function(make_test name)
             stdlib2
     )
 
-    add_test(test_${name} test_${name})
+    add_test(NAME test_${name}
+        COMMAND test_${name} ${ARGN}
+    )
 endfunction()
 
 make_test(exit)
+make_test(main_args "hej")
 make_test(offsetof)
 make_test(strlen)
 make_test(types)

--- a/test/src/test_main_args.c
+++ b/test/src/test_main_args.c
@@ -1,0 +1,10 @@
+#include "stdbool.h"
+
+int main2(int argc, char *argv[]) {
+    if (argc != 2) {
+        return 1;
+    }
+    const bool success = argv[1][0] == 'h' && argv[1][1] == 'e' &&
+                         argv[1][2] == 'j' && argv[1][3] == '\0';
+    return success ? 0 : 1;
+}


### PR DESCRIPTION
* Add new entry point _stdlib2_main
* _start calls _stdlib2_main, which calls exit and main2.
* Implement _start in assembler for Linux x86-64 with argument support.
* Add test for main with arguments. It will currently only pass on Linux
  x86-64.