### PR TITLE
Use float to get 4 byte allignment on both x86 and x86-64

### DIFF
--- a/test/src/test_offsetof.c
+++ b/test/src/test_offsetof.c
@@ -2,7 +2,7 @@
 
 struct S {
     char c;
-    double d;
+    float d;
 };
 
 int main2() {
@@ -10,7 +10,7 @@ int main2() {
         return 1;
     }
 
-    if (offsetof(struct S, d) != 8) {
+    if (offsetof(struct S, d) != 4) {
         return 1;
     }
 


### PR DESCRIPTION
Not tested on Windows though

Resolves #16 