### PR TITLE
Mark test_main_args as an expected failure on Windows

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,3 +23,8 @@ make_test(offsetof)
 make_test(strchr)
 make_test(strlen)
 make_test(types)
+
+if (WIN32)
+   # Missing support for args on Windows
+   set_tests_properties(test_main_args PROPERTIES WILL_FAIL TRUE)
+endif()


### PR DESCRIPTION
* Need to implement argument parsing on Windows before it will work