### PR TITLE
Use NUL char instead of NULL

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -52,13 +52,13 @@ char *strchr(const char *s, int c) {
         if (*s == c_) {
             return (char *)s;
         }
-    } while (*s++ != NULL);
+    } while (*s++ != '\0');
     return NULL;
 }
 
 size_t strlen(const char *str) {
     size_t len = 0;
-    while (str[len] != NULL) {
+    while (str[len] != '\0') {
         ++len;
     }
 


### PR DESCRIPTION
* Warning when compiling with clang:
 Comparison between pointer and integer ('char' and 'void *')
 -Wpointer-integer-compare