### PR TITLE
Clean up CMake language requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(stdlib2 C ASM)
+project(stdlib2 LANGUAGES C)
 
 include(cmake/platform_setup.cmake)
 include(cmake/compiler_workarounds.cmake)

--- a/cmake/platform_setup.cmake
+++ b/cmake/platform_setup.cmake
@@ -1,3 +1,7 @@
+if(NOT WIN32)
+    enable_language(ASM)
+endif()
+
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "i386")
     set(x86 1)
 else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(test_stdlib2)
+project(test_stdlib2 LANGUAGES C)
 
 function(make_test name)
     add_executable(test_${name} src/test_${name}.c)


### PR DESCRIPTION
Before (w/ mingw):
```
$ cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Windows
-- The C compiler identification is GNU 9.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /mingw64/bin/cc.exe
-- Check for working C compiler: /mingw64/bin/cc.exe
-- Check for working C compiler: /mingw64/bin/cc.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- The CXX compiler identification is GNU 9.2.0
-- Check for working CXX compiler: /mingw64/bin/c++.exe
-- Check for working CXX compiler: /mingw64/bin/c++.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
```
After (w/ mingw):
```
$ cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=Windows
-- The C compiler identification is GNU 9.2.0
-- Check for working C compiler: /mingw64/bin/cc.exe
-- Check for working C compiler: /mingw64/bin/cc.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
```

When targeting Linux it's similar, but with the assembler still there. No C++ compiler required anymore though.