### PR TITLE
Windows args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(${PROJECT_NAME}
         src/platform/win_x86_64/_exit.c
         src/platform/win_x86_64/_fd.c
         src/platform/win_x86_64/_write.c
-        src/start.c
+        src/platform/win_x86_64/start.c
     >
     $<$<PLATFORM_ID:Linux>:
         src/platform/linux/_fd.c

--- a/src/platform/win_x86_64/start.c
+++ b/src/platform/win_x86_64/start.c
@@ -1,0 +1,27 @@
+#include "stddef.h"
+#include "stdlib.h"
+
+#include <windows.h>
+
+int _stdlib2_start();
+
+enum { kMaxArgs = 64 };
+
+// Adapted from http://stackoverflow.com/a/13281447/4612829
+static int CommandLineToArgvA_simple(LPSTR command_line, char *argv[]) {
+    int argc = 0;
+    char *next_arg = strtok(command_line, " ");
+    while (next_arg && argc < kMaxArgs - 1) {
+        argv[argc++] = next_arg;
+        next_arg = strtok(NULL, " ");
+    }
+    argv[argc] = NULL;
+    return argc;
+}
+
+void _start() {
+    char *argv[kMaxArgs];
+    int argc = CommandLineToArgvA_simple(GetCommandLine(), argv);
+
+    exit(_stdlib2_start(argc, argv));
+}

--- a/src/start.c
+++ b/src/start.c
@@ -1,8 +1,0 @@
-#include "stdlib.h"
-#include "stddef.h"
-
-int _stdlib2_start();
-
-void _start() {
-    exit(_stdlib2_start(0, NULL));
-}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,11 +32,6 @@ make_test(strcmp)
 make_test(strtok)
 make_test(types)
 
-if (WIN32)
-   # Missing support for args on Windows
-   set_tests_properties(test_main_args PROPERTIES WILL_FAIL TRUE)
-endif()
-
 if(x86 AND UNIX)
     # I/O isn't implemented for Linux x86.
     set_tests_properties(test_fputc PROPERTIES WILL_FAIL TRUE)


### PR DESCRIPTION
Requires #47. Does not handle escaping and more than 64 args :)